### PR TITLE
Added license file, toc, and rearranged as per topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,61 @@
-# Awesome Hardware Production
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  
+
+- [Awesome Hardware Production](#awesome-hardware-production-)
+  - [Blogs, RSS feeds, and one-off articles](#blogs-rss-feeds-and-one-off-articles)
+  - [Components and procurement](#components-and-procurement)
+  - [Design for manufacturing](#design-for-manufacturing)
+  - [Device firmware](#device-firmware)
+  - [Shenzhen](#shenzhen)
+  - [Teardowns](#teardowns)
+  - [Testing and QA](#testing-and-qa)
+- [License](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Awesome Hardware Production [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+
 List of awesome resources on the interwebs for going to production with a hardware product.
 
+1. Blogs, RSS feeds, and one-off articles
 
-## Blogs and other written words
-- Bunnie Huang's [blog](https://www.bunniestudios.com)
-- [The Crowd Supply Guide](https://www.crowdsupply.com/guide)
-- Bolt VC [blog](https://blog.bolt.io)
-- Boldport went on a twitter rant one fine day and posted all the differences between prototyping and production [easily readable version](https://gist.github.com/anujdeshpande/8e8d533d6bc16ab40667c85aff171768)
+## Blogs, RSS feeds, and one-off articles
 
-## Device firmware
-- [Making Embedded Systems: Design Patterns for Great Software](https://www.amazon.com/Making-Embedded-Systems-Patterns-Software-ebook/dp/B005ZTO0LG) by Elecia White
+|Author/Company|Description|Link|
+|:--:|:--:|:--:|
+|Bunnie Huang| |[blog](https://www.bunniestudios.com)<br/>[rss](https://www.bunniestudios.com/blog/?feed=rss2)|
+|The Crowd Supply Guide||[crowdsupply.com](https://www.crowdsupply.com/guide)|
+|Bolt VC|| [blog](https://blog.bolt.io)|
+|Prototyping vs Production|Boldport went on a twitter rant one fine day and posted a comprehensive list of the differences between prototyping and production |[easily readable version](https://gist.github.com/anujdeshpande/8e8d533d6bc16ab40667c85aff171768)  <br/>[original twitter link](https://twitter.com/boldport/status/727162444724985857)|
 
-## Shenzhen
-- [The Essential Guide to Electronics in Shenzhen](https://www.crowdsupply.com/sutajio-kosagi/the-essential-guide-to-electronics-in-shenzhen) by Bunnie
-
-
-
-## Tools
+## Components and procurement
 
 |Author/Company|Name|Description|Link|
 |:--:|:--:|:--:|:--:|
-| Dragon Innovation | BOM Tool|It’s a Google Sheets template on steroids, providing a proven, pro-grade BOM format that companies can use with confidence.| [Link](https://www.dragoninnovation.com/dragon-standard-bom)|
-|Espressif Systems | ESP Jumpstart  |Software guide for writing production grade code on ESP32 and ESP8266|[Link](https://docs.espressif.com/projects/esp-jumpstart/en/latest/introduction.html)
-|Xobs|Exclave|Exclave is a factory test infrastructure, written in Rust.. A good [blog](https://www.bunniestudios.com/blog/?p=5450) explaining the project and it's motivations.|[Link](https://github.com/exclave/exclave)
+| Dragon Innovation | BOM Tool|It’s a Google Sheets template on steroids, providing a proven, pro-grade BOM format that companies can use with confidence.| [dragoninnovation.com](https://www.dragoninnovation.com/dragon-standard-bom)|
+|Anuj Deshpande & Kewal Shah|List of Indian ecommerce stores for procuring components ||[gist](https://gist.github.com/anujdeshpande/5e9475a0c4cefebe1c5288576171a6ca) 
 
-## Videos
+## Design for manufacturing
 
-- Dragon Innovation's [Design for Manufacturing Course](https://www.youtube.com/watch?v=84VxN9K_PMM&list=PLNTXUUIxHyNwrlAh2ZkaMTSBrgk86wC-a)
+|Author/Company|Name|Description|Link|
+|:--:|:--:|:--:|:--:|
+|Dragon Innovation| Design for Manufacturing Course||[YouTube](https://www.youtube.com/playlist?list=PLNTXUUIxHyNwrlAh2ZkaMTSBrgk86wC-a)|
+|Sean Cross (xobs)|Plastic is Forever: Designing Tomu's Injection-Molded Case||[YouTube](https://www.youtube.com/watch?v=Br5Ieo8USIw)|
+
+## Device firmware
+
+|Author/Company|Name|Description|Link|
+|:--:|:--:|:--:|:--:|
+|Elecia White|Making Embedded Systems: Design Patterns for Great Software||[Amazon.com](https://www.amazon.com/Making-Embedded-Systems-Patterns-Software-ebook/dp/B005ZTO0LG)|
+|Espressif Systems | ESP Jumpstart  |Software guide for writing production grade code on ESP32 and ESP8266|[docs.espressif.com](https://docs.espressif.com/projects/esp-jumpstart/en/latest/introduction.html)
+
+## Shenzhen
+
+|Author/Company|Name|Description|Link|
+|:--:|:--:|:--:|:--:|
+|Bunnie Huang|The Essential Guide to Electronics in Shenzhen||[crowdsupply.com](https://www.crowdsupply.com/sutajio-kosagi/the-essential-guide-to-electronics-in-shenzhen)
+
 
 ## Teardowns
 Learn from what other people have built.
@@ -38,8 +67,14 @@ Learn from what other people have built.
 |Dave Jones aka EEVBlog|[Link](https://www.eevblog.com/teardowns/)|
 
 
-## Procurement
+## Testing and QA
+|Author/Company|Name|Description|Link|
+|:--:|:--:|:--:|:--:|
+|Sean Cross (xobs)|Exclave|Exclave is a factory test infrastructure, written in Rust.. A good [blog](https://www.bunniestudios.com/blog/?p=5450) explaining the project and it's motivations.|[GitHub](https://github.com/exclave/exclave)
 
-|Name|Link|
-|:--:|:--:|
-|List of Indian ecommerce stores for procuring components |[Link](https://gist.github.com/anujdeshpande/5e9475a0c4cefebe1c5288576171a6ca) 
+
+
+
+# License
+
+[![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
- rearranged links as per topics as suggested by @sayanee - still guilty of keeping the generic blogs section
- added cc0. Thoughts?
- put the label from awesome lists standard
- added an autogenerated table of contents. I am using [doctoc](https://github.com/thlorenz/doctoc#installation)

Plenty of descriptions missing, but that can go in a different MR